### PR TITLE
#163707825 Admin should be able to edit a political party's name

### DIFF
--- a/app/party/views.py
+++ b/app/party/views.py
@@ -52,3 +52,21 @@ def get_a_party(party_id):
         'status': 404,
         'error': 'Party does not exist'
     }), 404)
+
+@party.route('/parties/<party_id>/name', methods=['PATCH'])
+def edit_a_party(party_id):
+    data = request.get_json()
+    name = data['name']
+
+    for party in PartyModel.parties_db:
+        if party['id'] == int(party_id):
+            party['name'] = name
+            return make_response(jsonify({
+                'status' : 200,
+                'data' : party
+                }), 200)
+
+    return make_response(jsonify({
+        'status' : 404,
+        'error' : 'Party Not Found'
+    }), 404)

--- a/tests/test_parties.py
+++ b/tests/test_parties.py
@@ -32,7 +32,7 @@ class TestPartyEndPoint(unittest.TestCase):
 
     def test_edit_a_party(self):
         '''Test to edit a specific party'''
-        response = self.client.put(path='/api/v1/parties/1/name', data=json.dumps(self.edit_data), content_type='application/json')
+        response = self.client.patch(path='/api/v1/parties/1/name', data=json.dumps(self.edit_data), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
     def test_delete_a_party(self):

--- a/tests/test_parties.py
+++ b/tests/test_parties.py
@@ -13,6 +13,9 @@ class TestPartyEndPoint(unittest.TestCase):
             'hqAddress' : 'Jubilee House, Nairobi',
             'logoUrl' : 'https://images.pexels.com/photos/866351/pexels-photo-866351.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940'
         }
+        self.edit_data={
+            'name': 'Nasa Party'
+        }
     def test_add_party(self):
         '''Test adding a party'''
         response = self.client.post(path='/api/v1/addparty',data=json.dumps(self.data), content_type='application/json')
@@ -28,7 +31,9 @@ class TestPartyEndPoint(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_edit_a_party(self):
-        pass
+        '''Test to edit a specific party'''
+        response = self.client.put(path='/api/v1/parties/1/name', data=json.dumps(self.edit_data), content_type='application/json')
+        self.assertEqual(response.status_code, 200)
 
     def test_delete_a_party(self):
         pass


### PR DESCRIPTION
**What does this PR do**
Creates a route that allows an admin user to edit a specific political party.

**Description of the task to be completed**
An admin should be able to send a PATCH request to the server to edit the name of a specific political party.

**How to test**
Clone the repository, on your terminal enter the following command `export FLASK_APP=run.py` followed by `flask run`. then copy the link _https://127.0.0.1/5000/api/v1/parties/<oarty-id>/name_ onto postman. Substitute part-id with the id of the party you want to be edited. change the method to PATCH, add required information on the body and click send.

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163707825