### PR TITLE
#163707948 Admin should be able to delete a party

### DIFF
--- a/app/party/views.py
+++ b/app/party/views.py
@@ -70,3 +70,19 @@ def edit_a_party(party_id):
         'status' : 404,
         'error' : 'Party Not Found'
     }), 404)
+
+@party.route('/parties/<party_id>', methods=['DELETE'])
+def delete_a_party(party_id):
+    for party in PartyModel.parties_db:
+        if party['id'] == int(party_id):
+            index = int(party_id) - 1
+            PartyModel.parties_db.pop(index)
+            return make_response(jsonify({
+                'status' : 200,
+                'message' : 'Party has been deleted successfuly'
+            }), 200)
+
+    return make_response(jsonify({
+        'status' : 404,
+        'error' : 'Party not found.'
+    }))

--- a/tests/test_parties.py
+++ b/tests/test_parties.py
@@ -13,6 +13,13 @@ class TestPartyEndPoint(unittest.TestCase):
             'hqAddress' : 'Jubilee House, Nairobi',
             'logoUrl' : 'https://images.pexels.com/photos/866351/pexels-photo-866351.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940'
         }
+
+        self.data_2={
+            'id' : '2',
+            'name': 'Naswa Party',
+            'hqAddress' : 'Naswa House, Nairobi',
+            'logoUrl' : 'https://images.pexels.com/photos/866351/pexels-photo-866351.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940'
+        }
         self.edit_data={
             'name': 'Nasa Party'
         }
@@ -20,6 +27,10 @@ class TestPartyEndPoint(unittest.TestCase):
         '''Test adding a party'''
         response = self.client.post(path='/api/v1/addparty',data=json.dumps(self.data), content_type='application/json')
         self.assertEqual(response.status_code, 201)
+
+        response = self.client.post(path='/api/v1/addparty',data=json.dumps(self.data_2), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
     def test_get_parties(self):
         '''Test to get all parties'''
         response = self.client.get(path='/api/v1/parties', content_type='application/json')
@@ -37,8 +48,8 @@ class TestPartyEndPoint(unittest.TestCase):
 
     def test_delete_a_party(self):
         '''Test to delete a specific party'''
-        response = self.client.delete(path='/api/v1.parties/1', content_type='application/json')
+        response = self.client.delete(path='/api/v1/parties/2', content_type='application/json')
         self.assertEqual(response.status_code, 200)
-
+    
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_parties.py
+++ b/tests/test_parties.py
@@ -36,7 +36,9 @@ class TestPartyEndPoint(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_delete_a_party(self):
-        pass
+        '''Test to delete a specific party'''
+        response = self.client.delete(path='/api/v1.parties/1', content_type='application/json')
+        self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**What does this PR do**
Create a route that allows admin users to delete a specific political party

**Description of the task to be completed**
An admin user should be able to send a DELETE request to the server to delete a specific party.

**How to test**
Clone this repository. On your terminal, navigate to the project folder and create a virtual environment using the requirements.txt file and activate it. Enter the following command `export FLASK_APP=run.py` followed by `flask run` in your terminal then copy the link _https://127.0.0.1/5000/api/v1/parties/<party-id>_ onto postman. Replace party-id with the id of the party you want to delete. Change the method to DELETE and click send.

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163707948
