### PR TITLE
#163708406 Creates route for getting all offices 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,5 +18,7 @@ def create_app(config_name):
     # Register blueprints
     from app.party import party
     app.register_blueprint(party, url_prefix='/api/v1')
-
+    from app.office import office
+    app.register_blueprint(office, url_prefix='/api/v1')
+    
     return app

--- a/app/config.py
+++ b/app/config.py
@@ -24,8 +24,8 @@ class ProductionConfig(Config):
     DEBUG = False
 
 # create a dictionary to store instances of different configurations environments.
-app_config = {
-    'testing' : TestingConfig,
-    'development' : DevelopmentConfig,
-    'production' : ProductionConfig
-}
+app_config = dict(
+    testing = TestingConfig,
+    development = DevelopmentConfig,
+    production = ProductionConfig
+)

--- a/app/models.py
+++ b/app/models.py
@@ -6,3 +6,11 @@ class PartyModel:
         self.hqAddress = hqAddress
         self.logoUrl = logoUrl
         self.id = len(parties_db) + 1
+
+class OfficeModel:
+    offices_db = []
+
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+        self.id = len(offices_db) + 1

--- a/app/office/__init__.py
+++ b/app/office/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+office = Blueprint('office', __name__)
+
+from . import views

--- a/app/office/views.py
+++ b/app/office/views.py
@@ -1,0 +1,17 @@
+from flask import jsonify, make_response, request
+from app.models import OfficeModel
+from app.office import office
+
+
+@office.route('/offices', methods=['GET'])
+def get_all_offices():
+    if len(OfficeModel.offices_db) <= 0:
+        return make_response(jsonify({
+            'status': 404,
+            'error' : 'No Offices to be showed'
+        }), 404)
+    else:
+        return make_response(jsonify({
+            'status' : 200,
+            'offices' : OfficeModel.offices_db
+        }), 200)

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -1,0 +1,36 @@
+import unittest
+import json
+from app import create_app
+
+class TestOfficeEndPoint(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.client = self.app.test_client()
+
+        self.data={
+            'id' : 1,
+            'name': 'Presidential',
+            'type': 'State Government'
+        }
+
+        self.data_2={
+            'id' : 2,
+            'name': 'Governor',
+            'type': 'Local Government'
+        }
+
+    def test_add_office(self):
+        pass
+    def test_get_offices(self):
+        '''Test to get all offices'''
+        response = self.client.get(path='/api/v1/offices', content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+    def test_get_an_office(self):
+        pass
+    def test_edit_an_office(self):
+        pass
+    def test_delete_an_office(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What does this PR do**
Creates a `/offices` route that allows users to get all offices

**Description of the task to be completed**
A user should be able to view all offices being contested for in the elections when they go to the `/offices` route

**How to test**
Clone or download this repository. On your terminal enter, the following command `export FLASK_APP=run.py` followed by `flask run`. then copy the link _https://127.0.0.1/5000/api/v1/offices_ onto postman, set the method to GET and send. If there are no offices to show, you will get a Status: 404 and a relevant error message.

**Pivotal Tracker stories**
https://www.pivotaltracker.com/story/show/163708406