### PR TITLE
#163708180 add route for creating new office

### DIFF
--- a/app/office/views.py
+++ b/app/office/views.py
@@ -15,3 +15,23 @@ def get_all_offices():
             'status' : 200,
             'offices' : OfficeModel.offices_db
         }), 200)
+
+@office.route('/addoffices', methods=['POST'])
+def add_office():
+    data = request.get_json()
+    name = data['name']
+    type = data['type']
+    id = len(OfficeModel.offices_db) + 1
+
+    new_office = {
+        'id' : id,
+        'name' : name,
+        'type' : type
+    }
+    
+    OfficeModel.offices_db.append(new_office)
+
+    return make_response(jsonify({
+        'Status' : 201,
+        'Office' : new_office
+    }), 201)

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -20,11 +20,18 @@ class TestOfficeEndPoint(unittest.TestCase):
         }
 
     def test_add_office(self):
-        pass
+        '''Test adding a new office'''
+        response = self.client.post(path='/api/v1/addoffices',data=json.dumps(self.data), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
+        response = self.client.post(path='/api/v1/addoffices',data=json.dumps(self.data_2), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
     def test_get_offices(self):
         '''Test to get all offices'''
         response = self.client.get(path='/api/v1/offices', content_type='application/json')
         self.assertEqual(response.status_code, 200)
+        
     def test_get_an_office(self):
         pass
     def test_edit_an_office(self):


### PR DESCRIPTION
**What does this PR do**
Adds new `/addoffices` route for adding new offices

**Description of the task to be completed**
An admin should be able to send a POST request to the server through the route `/addoffices` and be able to get a new office

**How to test**
Clone this repository. On your terminal, enter the following command `export FLASK_APP=run.py` followed by `flask run`. Copy the link _https://127.0.0.1/5000/api/v1/addoffices_ onto postman, change the method to POST, add required information on the body and click send.

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163708180