### PR TITLE
#163708521 adds route to get a specific office

### DIFF
--- a/app/office/views.py
+++ b/app/office/views.py
@@ -35,3 +35,17 @@ def add_office():
         'Status' : 201,
         'Office' : new_office
     }), 201)
+
+@office.route('/offices/<office_id>', methods=['GET'])
+def get_a_specific_office(office_id):
+    for office in OfficeModel.offices_db:
+        if office['id'] == int(office_id):
+            return make_response(jsonify({
+                'status' : 200,
+                'data' : office
+            }), 200)
+
+    return make_response(jsonify({
+        'status': 404,
+        'error': 'office does not exist'
+    }), 404)

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -33,7 +33,10 @@ class TestOfficeEndPoint(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         
     def test_get_an_office(self):
-        pass
+        '''Test to get a specific office'''
+        response = self.client.get(path='/api/v1/offices/1', content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        
     def test_edit_an_office(self):
         pass
     def test_delete_an_office(self):


### PR DESCRIPTION
**What does this PR do**
Allows users to view a specific political office when they access the `/offices/<office_id>` route.

**Description of the task to be completed**
A user should be able to view a specific political office when they send a get request to through the route `/offices/<office_id>` and they fill in the office_id value with a valid office id.

**How to test**
Clone this repository. On your terminal, enter the following command `export FLASK_APP=run.py` followed by `flask run`. Copy the link _https://127.0.0.1/5000/api/v1/offices/1_ onto postman, change the method to GET and click send. You should get a status code of 200 and the office info if it exists or a 404 status code with the relevant error message

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163708521