### PR TITLE
#163789480 Create route for deleting offices

### DIFF
--- a/app/office/views.py
+++ b/app/office/views.py
@@ -68,3 +68,19 @@ def edit_a_specific_office(office_id):
         'status' : 404,
         'error' : 'Office Not Found'
     }), 404)
+
+@office.route('/office/<office_id>', methods=['DELETE'])
+def delete_a_office(office_id):
+    for office in OfficeModel.offices_db:
+        if office['id'] == int(office_id):
+            index = int(office_id) - 1
+            OfficeModel.offices_db.pop(index)
+            return make_response(jsonify({
+                'status' : 200,
+                'message' : 'Office has been deleted successfuly'
+            }), 200)
+
+    return make_response(jsonify({
+        'status' : 404,
+        'error' : 'Office not found.'
+    }))

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -43,12 +43,14 @@ class TestOfficeEndPoint(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         
     def test_edit_an_office(self):
-        '''Test to edit a specific political party'''
+        '''Test to edit a specific political office'''
         response = self.client.patch(path='/api/v1/offices/2', data=json.dumps(self.edit_office), content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
     def test_delete_an_office(self):
-        pass
+        '''Test for deleting a specific office'''
+        response = self.client.delete(path='/api/v1/office/1', content_type='application/json')
+        self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -19,6 +19,12 @@ class TestOfficeEndPoint(unittest.TestCase):
             'type': 'Local Government'
         }
 
+        
+        self.data_3={
+            'id' : 3,
+            'name': 'MP',
+            'type': 'Local Government'
+        }
 
         self.edit_office={
             'name' : 'Senetor'
@@ -30,6 +36,9 @@ class TestOfficeEndPoint(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
 
         response = self.client.post(path='/api/v1/addoffices',data=json.dumps(self.data_2), content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
+        response = self.client.post(path='/api/v1/addoffices',data=json.dumps(self.data_3), content_type='application/json')
         self.assertEqual(response.status_code, 201)
 
     def test_get_offices(self):
@@ -49,7 +58,7 @@ class TestOfficeEndPoint(unittest.TestCase):
 
     def test_delete_an_office(self):
         '''Test for deleting a specific office'''
-        response = self.client.delete(path='/api/v1/office/1', content_type='application/json')
+        response = self.client.delete(path='/api/v1/office/3', content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What does this PR do**
Allows admin users to delete specific offices

**Description of the task to be completed**
An admin should be able to delete a specific office when they send a DELETE request to the `/office/<office_id>` route. The office_id variable should be replaced with a valid office id.

**How to test**
Clone this repository and navigate to the directory. On your terminal enter the following command `export FLASK_APP=run.py` followed by `flask run`. then copy the link _https://127.0.0.1/5000/api/v1/office/1_ onto postman, change the method to DELETE and click send.

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163789480
