### PR TITLE
#163885436 Update DELETE endpoint for offices

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ After the configuration, you will run the app uing the following commands
 | Method  | API Endpoint                  | Description                   |
 | ------- | ----------------------------- | ----------------------------- |
 | `GET`   | `/api/v1/offices`             | View all offices              |
-| `POST`  | `/api/v1/addoffices`          | Add a new office to the list  |
+| `POST`  | `/api/v1/offices`          | Add a new office to the list  |
 | `PATCH` | `/api/v1/offices/<office_id>` | update the name of a specific office |
 | `GET`   | `/api/v1/offices/<office_id>` | View a specific party from the list |
-| `DELETE`| `/api/v1/office/<office_id>`  | Deletes a specific office     |
+| `DELETE`| `/api/v1/offices/<office_id>`  | Deletes a specific office     |
 | `GET`   | `/api/v1/parties`             | Views all parties in the list |
-| `POST`  | `/api/v1/addparty`            | Adds a new party to the list  |
+| `POST`  | `/api/v1/parties`            | Adds a new party to the list  |
 | `PATCH` | `/api/v1/parties/<party_id>/name` | Edit name of a specific party |
 | `GET`   | `/api/v1/parties/<party_id>`  | View a specific party         |
 | `DELETE`| `/api/v1/parties/<party_id>`  | Deletes a specific party      |
@@ -59,7 +59,7 @@ After the configuration, you will run the app uing the following commands
 
 ### Creating a new office
 
-`/api/v1/addoffices`
+`/api/v1/offices`
 
 Payload
 
@@ -101,7 +101,7 @@ Expected response
 
 ### Add new party
 
-`/api/v1/addparty`
+`/api/v1/parties`
 
 Payload
 

--- a/app/office/views.py
+++ b/app/office/views.py
@@ -100,7 +100,7 @@ def edit_a_specific_office(office_id):
         'error' : 'Office Not Found'
     }), 404)
 
-@office.route('/office/<office_id>', methods=['DELETE'])
+@office.route('/offices/<office_id>', methods=['DELETE'])
 def delete_a_office(office_id):
     # loops through offices_db to find matching office and the removes it from offices db.
     for office in OfficeModel.offices_db:

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -84,7 +84,7 @@ class TestOfficeEndPoint(unittest.TestCase):
 
     def test_delete_an_office(self):
         '''Test for deleting a specific office'''
-        response = self.client.delete(path='/api/v1/office/3', content_type='application/json')
+        response = self.client.delete(path='/api/v1/offices/3', content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What does this PR do?**
Changes the route for deleting an office.

**Description of the task to be completed**
The delete office route should be changed from `/api/v1/office/<office_id>` to `/api/v1/offices/<office_id>`.

**How to manually test?**
Clone this repository and navigate to the project directory. Create a new virtual environment and initialize it with the packages in the requirements.txt file. After you have initialized the virtual environment and activating it, enter the following commands, `export FLASK_APP=run,py`, `export FLASK_ENV=development`, `export FLASK_DEBUG=1` and finally 'flask run'. You should also have postman installed to test the delete endpoint.

**Pivotal Tracer Stories**
https://www.pivotaltracker.com/story/show/163885436