### PR TITLE
#163895732 Fix posting office duplicates bug

### DIFF
--- a/app/office/views.py
+++ b/app/office/views.py
@@ -44,6 +44,14 @@ def add_office():
             'error': 'Name must be alphabetical with no spaces'
         }), 400)
 
+    #ensure no duplicate offices are added
+    for office in OfficeModel.offices_db:
+        if name == office['name']:
+            return make_response(jsonify({
+            'status': 400,
+            'error': 'An office with that name already exists'
+        }), 400)
+
     new_office = {
         'id' : id,
         'name' : name,

--- a/tests/test_offices.py
+++ b/tests/test_offices.py
@@ -64,6 +64,9 @@ class TestOfficeEndPoint(unittest.TestCase):
         response = self.client.post(path='/api/v1/offices',data=json.dumps(self.bad_data2), content_type='application/json')
         self.assertEqual(response.status_code, 400)
 
+        response = self.client.post(path='/api/v1/offices',data=json.dumps(self.data), content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
     def test_get_offices(self):
         '''Test to get all offices'''
         response = self.client.get(path='/api/v1/offices', content_type='application/json')


### PR DESCRIPTION
**What does this PR do?**
Fixes a bug in offices views where multiple offices with the same name could be added.

**Description of the task to be completed**
Updates validations for office post information and prevents admins from adding offices with the same names.

**How to Manually test?**
Clone this repository and navigate to the project directory. Create a new virtual environment and initialize it with the packages in the requirements.txt file. After you have initialized the virtual environment and activating it, enter the following commands, `export FLASK_APP=run,py`, `export FLASK_ENV=development`, `export FLASK_DEBUG=1` and finally 'flask run'. You should also have postman installed to test the endpoints. Try posting the payload data on the read me file twice, you should get a 400 error with relevant error message 

**Pivotal Tracker Stories**
https://www.pivotaltracker.com/story/show/163895732